### PR TITLE
Fixed problem with unnecessary recoveries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 bin
 build
 Gemfile.lock
+.idea/

--- a/source/install/armada-runner
+++ b/source/install/armada-runner
@@ -102,7 +102,7 @@ case "$1" in
 
         set_external_ip
 
-        docker_start_timestamp=$(python -c "import os; print(int(os.path.getctime('/proc/$(pidof docker)')))")
+        docker_start_timestamp=$(python -c "import os; print(int(os.path.getctime('/proc/$(cat /var/run/docker.pid)')))")
 
         docker run -d \
             --privileged=true \

--- a/source/install/armada-runner
+++ b/source/install/armada-runner
@@ -102,7 +102,7 @@ case "$1" in
 
         set_external_ip
 
-        # In background there might some long running Docker process while Armada starts, so we take earliest start time of all docker processes
+        # We take earliest start time of all docker processes
         docker_start_timestamp=$(python -c "import os; print(min(map(lambda x: int(os.path.getctime('/proc/' + x)),'$(pidof docker)'.split())))")
 
         docker run -d \

--- a/source/install/armada-runner
+++ b/source/install/armada-runner
@@ -102,7 +102,8 @@ case "$1" in
 
         set_external_ip
 
-        docker_start_timestamp=$(python -c "import os; print(int(os.path.getctime('/proc/$(cat /var/run/docker.pid)')))")
+        # In background there might some long running Docker process while Armada starts, so we take earliest start time of all docker processes
+        docker_start_timestamp=$(python -c "import os; print(min(map(lambda x: int(os.path.getctime('/proc/' + x)),'$(pidof docker)'.split())))")
 
         docker run -d \
             --privileged=true \


### PR DESCRIPTION
When armada service is starting, runner retrieves information when docker started. If there is some Docker's long running process running then `pidof` might not return proper PID thus Armada may accidentally attempt to recover services. Simplest solution to this issue is to read PID from Docker's .pid file.
