### PR TITLE
We only want the first line of output.

### DIFF
--- a/source/install/armada-runner
+++ b/source/install/armada-runner
@@ -29,7 +29,7 @@ set_external_ip() {
             default_interface=eth1
         fi
     fi
-    external_ip=`ifconfig ${default_interface} | grep 'inet' | awk '{print $2}' | head -1`
+    external_ip=`ifconfig ${default_interface} | grep 'inet ' | awk '{print $2}' | cut -d: -f2 | head -1`
 }
 
 # Check if docker is present and available.

--- a/source/install/armada-runner
+++ b/source/install/armada-runner
@@ -29,7 +29,7 @@ set_external_ip() {
             default_interface=eth1
         fi
     fi
-    external_ip=`ifconfig ${default_interface} | grep 'inet' | awk '{print $2}' | cut -d: -f2`
+    external_ip=`ifconfig ${default_interface} | grep 'inet' | awk '{print $2}' | head -1`
 }
 
 # Check if docker is present and available.


### PR DESCRIPTION
Using cut can yield multiple lines. When fed into `docker run`, the
second chunk will be taken as the image name.
