### PR TITLE
Warn that command wont work if daemon failed.

### DIFF
--- a/source/install/install.sh
+++ b/source/install/install.sh
@@ -141,6 +141,10 @@ else
     exit 1
 fi
 
+if [ $? != 0 ]; then
+    echo "Warning: If armada daemon failed to start, the 'armada' command will not work."
+fi
+
 hash -r
 
 #===================================================================================================


### PR DESCRIPTION
Using docker volumes to link in armada is great because docker is
effectively the package manager. However, the cost of this magic is
that it is non-obvious that failure to start the daemon container
will break the 'armada' command.
