### PR TITLE
Warn that command wont work if daemon failed.

### DIFF
--- a/source/intro/getting_started/install.html.erb
+++ b/source/intro/getting_started/install.html.erb
@@ -73,8 +73,13 @@ optional arguments:
 
         <br>
 
-        <p/>
+        <p>
         If everything looks good, we can get our feet wet
         and go <a href="/intro/getting_started/running_services/">run some services</a>!
+        </p>
 
+        <p>
+        If not, check <span class="inline-command">/var/log/armada.log</span>.
+        If the armada docker container did not run, the <span class="inline-command">armada</span> command will not work.
+        </p>
 </div>


### PR DESCRIPTION
Using docker volumes to link in armada is great because docker is
effectively the package manager. However, the cost of this magic is
that it is non-obvious that failure to start the daemon container
will break the 'armada' command.
