### PR TITLE
Invoke python directly rather than shell script.

### DIFF
--- a/source/install/armada
+++ b/source/install/armada
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env python2
+import sys
+sys.path.append('/opt/armada')
+from armada_command import armada
 
-export PYTHONPATH="/opt/armada:${PYTHONPATH}"
-
-python2 -m armada_command.armada $@
+armada.main()


### PR DESCRIPTION
This eliminates the shell process so armada commands only start one
process rather than two. Admittedly this isn't really a big deal but it
seems like a simpler and more typical way to handle python command-line
applications.
