### PR TITLE
Improved docs

### DIFF
--- a/source/docs/advanced_features/clustering.erb
+++ b/source/docs/advanced_features/clustering.erb
@@ -79,7 +79,6 @@ Service has been stopped.
 Running microservice example-clustering (renamed from example) from dockyard: dockyard.armada.sh (alias: armada) on remote ship: 192.168.3.11...
 Service is running in container 054546732f69 available at addresses:
 192.168.3.11:32769 (80/tcp)
-192.168.3.11:32768 (22/tcp)
         </div>
         <div class="command">$ armada list</div>
         <div class="command-result">

--- a/source/docs/advanced_features/clustering.erb
+++ b/source/docs/advanced_features/clustering.erb
@@ -1,13 +1,11 @@
 <link type="text/css" rel="stylesheet" href="/assets/css/article.css"/>
 <div class="content">
     <h3>Clustering.</h3>
-    <p/>
-    Usually in production environment, we have more than one server. With Armada you can simply join them together forming a cluster.
-    This allows you to manage services on any ship from any ship within such cluster.
+    <p>Usually in production environment, we have more than one server. With Armada you can simply join them together forming a cluster.
+    This allows you to manage services on any ship from any ship within such cluster.</p>
 
     <h4>Joining ships.</h4>
-    <p/>
-    Let's say we have two servers running Armada services: <span class="inline-name">192.168.3.10</span> and <span class="inline-name">192.168.3.11</span>.
+    <p>Let's say we have two servers running Armada services: <span class="inline-name">192.168.3.10</span> and <span class="inline-name">192.168.3.11</span>.</p>
     <br/>
     <div class="code">
     <div class="host-info">Host: 192.168.3.10</div>
@@ -29,9 +27,9 @@ armada          192.168.3.11:8900   27cc85f15888    passing     -
 example-2       192.168.3.11:32422  efe0e1ab41e5    passing     ['env:dev']
     </div>
     </div>
-    <p/>
+
     <br/>
-    We can join them together with simple <span class="inline-name">armada join</span> command:
+    <p>We can join them together with simple <span class="inline-name">armada join</span> command:</p>
     <div class="code">
     <div class="host-info">Host: 192.168.3.10</div>
     <div class="command">$ armada join 192.168.3.11</div>
@@ -48,8 +46,7 @@ example-2       192.168.3.11:32422  efe0e1ab41e5    passing     ['env:dev']
     </div>
     </div>
     <br/>
-    <p/>
-    <span class="inline-name">armada info</span> command displays core information about our cluster.
+    <p><span class="inline-name">armada info</span> command displays core information about our cluster.</p>
     <div class="code">
         <div class="host-info">Host: 192.168.3.10</div>
         <div class="command">$ armada info</div>
@@ -62,11 +59,11 @@ WARNING: We cannot survive leader leaving/failure.
 Such configuration should only be used in development environments.
         </div>
     </div>
-    <p/>
+    <p>
     Notice that when forming a cluster, the ship that we joined to is marked as a leader.
-    Another important thing is a displayed warning. We will cover it below.
+    Another important thing is a displayed warning. We will cover it below.</p>
     <br/><br/>
-    We can now manage services on any ship. Let's try it out!!
+    <p>We can now manage services on any ship. Let's try it out!!</p>
     <div class="code">
     <div class="host-info">Host: 192.168.3.10</div>
     <div class="command">$ armada stop example-2</div>
@@ -86,20 +83,17 @@ Name                Address             ID              Status      Tags
 armada              192.168.3.10:8900   ae148a2d3a1a    passing     -
 armada              192.168.3.11:8900   27cc85f15888    passing     -
 example-1           192.168.3.10:32868  e93f803bbea8    passing     ['env:dev']
-
-
 example-clustering  192.168.3.11:32769  054546732f69    passing     ['env:dev']
         </div>
     </div>
-    <p/>
+
     <h4>Production environment.</h4>
-    <p/>
-    Right now, our cluster has one <span class="inline-name">leader</span>, one <span class="inline-name">ship</span> and zero <span class="inline-name">commanders</span>.
+
+    <p>Right now, our cluster has one <span class="inline-name">leader</span>, one <span class="inline-name">ship</span> and zero <span class="inline-name">commanders</span>.
     There can be only one <span class="inline-name">leader</span> and multiple <span class="inline-name">commanders</span>.
     In case of failure, they are responsible for making recovery decisions based on <a href="https://raft.github.io">Raft Consensus</a>.
     Because decisions are based on majority, we suggest having at least 2 <span class="inline-name">commanders</span> in addition to <span class="inline-name">leader</span>.
-    To promote a ship to <span class="inline-name">commander</span> role
-    run <span class="inline-name">armada promote</span> command.
+    To promote a ship to <span class="inline-name">commander</span> role run <span class="inline-name">armada promote</span> command.</p>
     <h4>Hints.</h4>
     <ul class="text">
         <li>To remove a ship from cluster run <span class="inline-name">armada shutdown</span> followed by <span class="inline-name">sudo service armada start</span></li>

--- a/source/docs/advanced_features/clustering.erb
+++ b/source/docs/advanced_features/clustering.erb
@@ -1,10 +1,12 @@
 <link type="text/css" rel="stylesheet" href="/assets/css/article.css"/>
 <div class="content">
     <h3>Clustering.</h3>
+    <p/>
     Usually in production environment, we have more than one server. With Armada you can simply join them together forming a cluster.
     This allows you to manage services on any ship from any ship within such cluster.
 
     <h4>Joining ships.</h4>
+    <p/>
     Let's say we have two servers running Armada services: <span class="inline-name">192.168.3.10</span> and <span class="inline-name">192.168.3.11</span>.
     <br/>
     <div class="code">
@@ -92,6 +94,7 @@ example-clustering  192.168.3.11:32769  054546732f69    passing     ['env:dev']
     </div>
     <p/>
     <h4>Production environment.</h4>
+    <p/>
     Right now, our cluster has one <span class="inline-name">leader</span>, one <span class="inline-name">ship</span> and zero <span class="inline-name">commanders</span>.
     There can be only one <span class="inline-name">leader</span> and multiple <span class="inline-name">commanders</span>.
     In case of failure, they are responsible for making recovery decisions based on <a href="https://raft.github.io">Raft Consensus</a>.

--- a/source/docs/advanced_features/health_checks.erb
+++ b/source/docs/advanced_features/health_checks.erb
@@ -18,10 +18,10 @@
     </ul>
 
     <h4>Default health-check</h4>
-    <p/>
+    <p>
     Every service based on <span class="inline-name">microservice</span> image has a default health-check which checks whether port 80 inside the container is open.
     If it is, we assume the service works and return '<span class="inline-name">passing</span>' status. Otherwise '<span class="inline-name">critical</span>' is returned.
-    You can disable it in Dockerfile with one line:
+    You can disable it in Dockerfile with one line:</p>
     <br/><span class="inline-name">RUN rm -rf /opt/microservice/health-checks</span>
 
 

--- a/source/docs/advanced_features/health_checks.erb
+++ b/source/docs/advanced_features/health_checks.erb
@@ -3,7 +3,7 @@
     <h3>Health-checks.</h3>
     <p/>
     Health-checks are simple scripts which provide knowledge about what's going on inside of our service. They are running inside the service's container
-    and report it's status to Armada agent. You can see it in 'Status' column of <span class="inline-name">armada list</span> command.
+    and report its status to Armada agent. You can see it in 'Status' column of <span class="inline-name">armada list</span> command.
 
     <ul class="text">
         <li>
@@ -13,7 +13,7 @@
         <span class="inline-name">warning</span> - service works, but there's something wrong with it. (e.g.: a lot of errors being logged)
         </li>
          <li>
-        <span class="inline-name">critical</span> - service doesn't work! Armada won't use it's address in any load-balancer until the status changes back to <span class="inline-name">passing</span> or <span class="inline-name">warning</span>.
+        <span class="inline-name">critical</span> - service doesn't work! Armada won't use its address in any load-balancer until the status changes back to <span class="inline-name">passing</span> or <span class="inline-name">warning</span>.
         </li>
     </ul>
 

--- a/source/docs/advanced_features/health_checks.erb
+++ b/source/docs/advanced_features/health_checks.erb
@@ -1,0 +1,51 @@
+<link type="text/css" rel="stylesheet" href="/assets/css/article.css"/>
+<div class="content">
+    <h3>Health-checks.</h3>
+    <p/>
+    Health-checks are simple scripts which provide knowledge about what's going on inside of our service. They are running inside the service's container
+    and report it's status to Armada agent. You can see it in 'Status' column of <span class="inline-name">armada list</span> command.
+
+    <ul class="text">
+        <li>
+        <span class="inline-name">passing</span> - everything works!
+        </li>
+         <li>
+        <span class="inline-name">warning</span> - service works, but there's something wrong with it. (e.g.: a lot of errors being logged)
+        </li>
+         <li>
+        <span class="inline-name">critical</span> - service doesn't work! Armada won't use it's address in any load-balancer until the status changes back to <span class="inline-name">passing</span> or <span class="inline-name">warning</span>.
+        </li>
+    </ul>
+
+    <h4>Default health-check</h4>
+    <p/>
+    Every service based on <span class="inline-name">microservice</span> image has a default health-check which checks whether port 80 inside the container is open.
+    If it is, we assume the service works and return '<span class="inline-name">passing</span>' status. Otherwise '<span class="inline-name">critical</span>' is returned.
+    You can disable it in Dockerfile with one line:
+    <br/><span class="inline-name">RUN rm -f /opt/microservice/health-checks"</span>
+
+
+    <h4>Custom health-checks</h4>
+    <p/>
+    In order to add a health-check to your service, simply create health-checks directory in your project and add your health-checks there. There are some things you should know:
+    <ul class="text">
+        <li>
+        <span class="inline-name">shebangs</span> - Since you can write your health check in any language you want,
+            remember to add a shebang to let a system know how to run your script.
+            For example for python health-check you'd add <span class="inline-name">#!/usr/bin/env python</span>.
+
+        </li>
+         <li>
+        <span class="inline-name">exit codes</span> - Health-checks report their status by exiting with an integer code. 0 means <span class="inline-name">passing</span>, 1 means <span class="inline-name">warning</span> and 2 means <span class="inline-name">critical</span>.
+        </li>
+         <li>
+        <span class="inline-name">the worst outcome</span> - Each health-check script can return a different status. Final service's status is "the worst" of all statuses.
+             So if you have 10 health checks, 9 of them exit with code 0 (<span class="inline-name">passing</span>),
+             and one exits with code 2 (<span class="inline-name">critical</span>) your service's final status will be <span class="inline-name">critical</span>.
+        </li>
+    </ul>
+
+    <h4>Example</h4>
+    <p/>
+    Instead of providing some dummy example, we suggest you check out <a href="https://github.com/armadaplatform/mysql">armada mysql repository</a>
+    to see how custom health-checks can be used in real life.

--- a/source/docs/advanced_features/health_checks.erb
+++ b/source/docs/advanced_features/health_checks.erb
@@ -1,16 +1,16 @@
 <link type="text/css" rel="stylesheet" href="/assets/css/article.css"/>
 <div class="content">
     <h3>Health-checks.</h3>
-    <p/>
-    Health-checks are simple scripts which provide knowledge about what's going on inside of our service. They are running inside the service's container
+    <p>
+    Health-checks are simple scripts which inform us about status of our service. They are running inside the service's container
     and report its status to Armada agent. You can see it in 'Status' column of <span class="inline-name">armada list</span> command.
-
+    </p>
     <ul class="text">
         <li>
         <span class="inline-name">passing</span> - everything works!
         </li>
          <li>
-        <span class="inline-name">warning</span> - service works, but there's something wrong with it. (e.g.: a lot of errors being logged)
+        <span class="inline-name">warning</span> - service works, but there's something wrong with it (e.g.: a lot of errors being logged).
         </li>
          <li>
         <span class="inline-name">critical</span> - service doesn't work! Armada won't use its address in any load-balancer until the status changes back to <span class="inline-name">passing</span> or <span class="inline-name">warning</span>.
@@ -22,30 +22,37 @@
     Every service based on <span class="inline-name">microservice</span> image has a default health-check which checks whether port 80 inside the container is open.
     If it is, we assume the service works and return '<span class="inline-name">passing</span>' status. Otherwise '<span class="inline-name">critical</span>' is returned.
     You can disable it in Dockerfile with one line:
-    <br/><span class="inline-name">RUN rm -f /opt/microservice/health-checks"</span>
+    <br/><span class="inline-name">RUN rm -rf /opt/microservice/health-checks</span>
 
 
     <h4>Custom health-checks</h4>
-    <p/>
-    In order to add a health-check to your service, simply create health-checks directory in your project and add your health-checks there. There are some things you should know:
+    <p>In order to add a health-check to your service, simply create health-checks directory in your project and add your health-checks there. There are some things you should know:</p>
     <ul class="text">
         <li>
-        <span class="inline-name">shebangs</span> - Since you can write your health check in any language you want,
+        <b>shebangs:</b> Since you can write your health check in any language you want,
             remember to add a shebang to let a system know how to run your script.
             For example for python health-check you'd add <span class="inline-name">#!/usr/bin/env python</span>.
-
         </li>
+        <br/>
          <li>
-        <span class="inline-name">exit codes</span> - Health-checks report their status by exiting with an integer code. 0 means <span class="inline-name">passing</span>, 1 means <span class="inline-name">warning</span> and 2 means <span class="inline-name">critical</span>.
+        <b>exit codes:</b> Health-checks report their status by exiting with an integer code. 0 means <span class="inline-name">passing</span>, 1 means <span class="inline-name">warning</span> and 2 means <span class="inline-name">critical</span>.
         </li>
+        <br/>
          <li>
-        <span class="inline-name">the worst outcome</span> - Each health-check script can return a different status. Final service's status is "the worst" of all statuses.
+        <b>the worst outcome:</b> Each health-check script can return a different status. Final service's status is "the worst" of all statuses.
              So if you have 10 health checks, 9 of them exit with code 0 (<span class="inline-name">passing</span>),
              and one exits with code 2 (<span class="inline-name">critical</span>) your service's final status will be <span class="inline-name">critical</span>.
         </li>
+        <br/>
     </ul>
 
     <h4>Example</h4>
-    <p/>
-    Instead of providing some dummy example, we suggest you check out <a href="https://github.com/armadaplatform/mysql">armada mysql repository</a>
+    <p>
+    Instead of providing some dummy example, we suggest you check out <a href="https://github.com/armadaplatform/mysql/blob/master/health-checks/mysql-ok">armada mysql repository</a>
     to see how custom health-checks can be used in real life.
+    <br/>
+    As you can see, we're logging <i>"Error. MySQL is not running."</i> information.
+    This is message will be visible in service's health-checks logs, which, in case of mysql service, you can see either by
+    running <span class="inline-name">armada diagnose mysql</span> command,
+    or by reading health-checks logs file: <span class="inline-name">armada ssh mysql tail /var/log/supervisor/run_health_checks*</span>
+    </p>

--- a/source/docs/advanced_features/service_discovery.html.erb
+++ b/source/docs/advanced_features/service_discovery.html.erb
@@ -1,6 +1,6 @@
 <link type="text/css" rel="stylesheet" href="/assets/css/article.css"/>
 <div class="content">
-    <h3>Service discovery.</h3>
+    <h3>Joining services.</h3>
 
     <p/>
     Service discovery allows you to specify dependencies between two or more services, without hardcoding their

--- a/source/docs/advanced_features/service_discovery.html.erb
+++ b/source/docs/advanced_features/service_discovery.html.erb
@@ -1,6 +1,6 @@
 <link type="text/css" rel="stylesheet" href="/assets/css/article.css"/>
 <div class="content">
-    <h3>Joining services.</h3>
+    <h3>Service discovery.</h3>
 
     <p/>
     Service discovery allows you to specify dependencies between two or more services, without hardcoding their

--- a/source/docs/basic_service_discovery.html.erb
+++ b/source/docs/basic_service_discovery.html.erb
@@ -236,7 +236,7 @@ Peter's coffee count is now 5.
         Services that enter <span class="inline-name">critical</span> state (for example because
         of ship failure) will automatically drop out from the round robin.
         Hence the emphasis on using/writing proper health checks. That topic is discussed in more details
-        <a href="/docs/page_under_construction#health_checks">here</a>.
+        <a href="/docs/advanced_features/health_checks">here</a>.
         <br/>
 
         <p/>

--- a/source/docs/basic_service_discovery.html.erb
+++ b/source/docs/basic_service_discovery.html.erb
@@ -60,7 +60,6 @@
 Running microservice main-haproxy from dockyard: dockyard.armada.sh (alias: armada) locally...
 Service is running in container 908d83383b40 available at addresses:
   192.168.3.168:80 (80/tcp)
-  192.168.3.168:49228 (22/tcp)
             </div>
 
             <div class="command">$ armada list</div>
@@ -119,7 +118,6 @@ main-haproxy    192.168.3.168:80     908d83383b40  passing  ['env:dev/guide']
 Running microservice magellan from dockyard: dockyard.armada.sh (alias: armada) locally...
 Service is running in container 30ae20b5837f available at addresses:
   192.168.3.168:49230 (80/tcp)
-  192.168.3.168:49231 (22/tcp)
             </div>
 
             <div class="command">$ armada list</div>
@@ -182,7 +180,6 @@ Stopping service 30ae20b5837f...
 Service has been stopped.
 Running microservice magellan from dockyard: dockyard.armada.sh (alias: armada) locally...
 Service has been restarted and is running in container 58cb71ec7835 available at addresses:
-  192.168.3.168:49232 (22/tcp)
   192.168.3.168:49233 (80/tcp)
             </div>
         </div>

--- a/source/docs/building_service.html.erb
+++ b/source/docs/building_service.html.erb
@@ -317,7 +317,7 @@ coffee-counter  192.168.3.168:49227  93697f6e1847  passing  -
         That's because it is using default health check, that just checks if we are able
         to connect to the service's specified port.
         If you need more sophisticated health checks that topic is covered
-        <a href="/docs/page_under_construction#health_checks">here</a>.
+        <a href="/docs/advanced_features/health_checks">here</a>.
 
         <p/>
         Now that we have our service up and running properly, let's move on to

--- a/source/docs/building_service.html.erb
+++ b/source/docs/building_service.html.erb
@@ -274,7 +274,6 @@ Successfully built b595776d8041
 Running microservice coffee-counter from dockyard:  (alias: local) locally...
 Service is running in container 93697f6e1847 available at addresses:
   192.168.3.168:49227 (80/tcp)
-  192.168.3.168:49226 (22/tcp)
             </div>
 
             <div class="command">coffee-counter$ curl -X POST http://192.168.3.168:49227/drink/Peter/2</div>

--- a/source/docs/service_configuration.html.erb
+++ b/source/docs/service_configuration.html.erb
@@ -275,7 +275,6 @@ Successfully built 61deaeef72b8
 Running microservice coffee-counter from dockyard:  (alias: local) locally...
 Service is running in container ca9ab262e9b2 available at addresses:
   192.168.3.168:49241 (80/tcp)
-  192.168.3.168:49240 (22/tcp)
                 </div>
                 <div class="command">$ curl -X POST 192.168.3.168:49241/drink/Peter/4</div>
                 <div class="command-result">
@@ -287,7 +286,6 @@ You can't drink that much! The limit is 2.
 Running microservice coffee-counter from dockyard:  (alias: local) locally...
 Service is running in container 6d826bf3eb92 available at addresses:
   192.168.3.168:49243 (80/tcp)
-  192.168.3.168:49242 (22/tcp)
                 </div>
                 <div class="command">$ curl -X POST 192.168.3.168:49243/drink/Peter/4</div>
                 <div class="command-result">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -169,7 +169,6 @@ Image has been pushed.
 Running microservice chat-service from dockyard: dockyard.initech.com locally...
 Service is running in container fc6776c8f6da available at addresses:
   192.168.1.43:49272 (80/tcp)
-  192.168.1.43:49271 (22/tcp)
                     </div>
                 </div>
 

--- a/source/intro/getting_started/building_services.html.erb
+++ b/source/intro/getting_started/building_services.html.erb
@@ -59,7 +59,6 @@ Removing intermediate container b9b891eb90ce
 Running microservice example from dockyard:  (alias: local) locally...
 Service is running in container efe0e1ab41e5 available at addresses:
   192.168.3.141:49156 (80/tcp)
-  192.168.3.141:49155 (22/tcp)
             </div>
             <div class="command">/tmp/example$ curl 192.168.3.141:49156</div>
             <div class="command-result">
@@ -97,7 +96,6 @@ Service is running in container efe0e1ab41e5 available at addresses:
 Running microservice dockyard from dockyard: dockyard.armada.sh (alias: armada) locally...
 Service is running in container 27cc85f15888 available at addresses:
   <font color="yellow">192.168.3.141:10000</font> (80/tcp)
-  192.168.3.141:49161 (22/tcp)
             </div>
         </div>
 
@@ -222,7 +220,6 @@ example   192.168.3.141:49160  <font color="yellow">f7a</font>09fb19009  passing
             <div class="command-result">
 Restarting service f7a...
 Service has been restarted and is running in container 50d6e904a684 available at addresses:
-  192.168.3.141:49159 (22/tcp)
   192.168.3.141:49160 (80/tcp)
             </div>
             <div class="command">$ curl 192.168.3.141:49184</div>

--- a/source/intro/getting_started/creating_new_service.html.erb
+++ b/source/intro/getting_started/creating_new_service.html.erb
@@ -88,8 +88,8 @@ Successfully built c0b134888b7a
         on which our template is based.
         This in turn is based on image <span class="inline-command">microservice</span>
         which is our recommended base docker image for microservices run on Armada.
-        It contains some useful features such as autoregistering service in Armada catalog, built-in
-        <span class="inline-command">sshd</span> and some other service discovery goodies.
+        It contains some useful features such as autoregistering service in Armada catalog,
+        and some other service discovery goodies.
 
         <p/>
         Now, we can test our new service by running it from local dockyard
@@ -112,7 +112,6 @@ Pushing tag for rev [f87353915cb3] on {http://192.168.3.141:10000/v1/repositorie
             <div class="command-result">
 Running microservice upcase-service from dockyard: 192.168.3.141:10000 (alias: myrepo) locally...
 Service is running in container 9707b42a4c77 available at addresses:
-  192.168.3.141:49167 (22/tcp)
   192.168.3.141:49168 (80/tcp)
             </div>
             <div class="command">~/uppercase-service$ curl http://192.168.3.141:49168/shout/Armada-is-cool!</div>

--- a/source/intro/getting_started/running_services.html.erb
+++ b/source/intro/getting_started/running_services.html.erb
@@ -12,14 +12,12 @@
 Running microservice example from dockyard: dockyard.armada.sh (alias: armada) locally...
 Service is running in container 789731dc0ca4 available at addresses:
   192.168.3.141:49156 (80/tcp)
-  192.168.3.141:49155 (22/tcp)
             </div>
         </div>
 
 
         <p/>
-        First address is main service endpoint (mapping to port 80 inside service container).
-        Second address will allow us to ssh inside service container. We'll cover this topic later on.
+        Listed address is main service endpoint (mapping to port 80 inside service container).
 
         So, let's check what our service can do:
 
@@ -62,7 +60,6 @@ Service is running in container 789731dc0ca4 available at addresses:
             <div class="command-result">
 Running microservice example from dockyard: dockyard.armada.sh (alias: armada) locally...
 Service is running in container a9992ef1f772 available at addresses:
-  192.168.3.141:49157 (22/tcp)
   192.168.3.141:49158 (80/tcp)
             </div>
             <div class="command">$ curl 192.168.3.141:49158</div>
@@ -119,7 +116,6 @@ example  192.168.3.141:49158  a9992ef1f772  passing  -
             <div class="command-result">
 Running microservice example from dockyard: dockyard.armada.sh (alias: armada) locally...
 Service is running in container f7a09fb19009 available at addresses:
-  192.168.3.141:49159 (22/tcp)
   192.168.3.141:49160 (80/tcp)
             </div>
             <div class="command">$ armada list</div>

--- a/source/intro/getting_started/ships.html.erb
+++ b/source/intro/getting_started/ships.html.erb
@@ -106,7 +106,6 @@ Such configuration should only be used in development environments.
             <div class="command-result">
 Running microservice upcase-service from dockyard: 192.168.3.141:10000 (alias: myrepo) on remote ship: 192.168.3.177...
 Service is running in container aebd4da2633d available at addresses:
-  192.168.3.177:49155 (22/tcp)
   192.168.3.177:49156 (80/tcp)
             </div>
             <div class="command">$ armada list</div>

--- a/source/intro/highlights.html.erb
+++ b/source/intro/highlights.html.erb
@@ -9,7 +9,6 @@
 Running microservice fraud-finder from dockyard: dockyard.initech.com on remote ship: behemot...
 Service is running in container c803fd8129a7 available at addresses:
   192.168.3.141:49168 (80/tcp)
-  192.168.3.141:49167 (22/tcp)
             </div>
             <div class="command">$ armada stop daily-promo-mailing</div>
             <div class="command-result">
@@ -60,7 +59,6 @@ Image has been pushed.
 Running microservice killer-service from dockyard: dockyard.local locally...
 Service is running in container 81d6b5473e39 available at addresses:
   192.168.0.50:49397 (80/tcp)
-  192.168.0.50:49396 (22/tcp)
             </div>
         </div>
 
@@ -86,7 +84,6 @@ Last login: Wed Sep 24 10:43:28 2014 from 10.0.2.2
 Running microservice killer-service from dockyard: dockyard.local locally...
 Service is running in container cda8e994567b available at addresses:
   192.168.0.50:4999 (80/tcp)
-  192.168.0.50:2999 (22/tcp)
             </div>
         </div>
 
@@ -110,7 +107,6 @@ Image has been pushed.
 Restarting service killer-service...
 Service has been restarted and is running in container 275a58a771ec available at addresses:
   192.168.0.50:49399 (80/tcp)
-  192.168.0.50:49398 (22/tcp)
             </div>
         </div>
 
@@ -122,7 +118,6 @@ Service has been restarted and is running in container 275a58a771ec available at
 Running microservice games-portal from dockyard: dockyard.local locally...
 Service is running in container fc6776c8f6da available at addresses:
   192.168.1.43:49272 (80/tcp)
-  192.168.1.43:49271 (22/tcp)
             </div>
             <div class="command">$ curl http://green-theme.games-portal.example.com</div>
             <div class="command-result">

--- a/source/layouts/_documentation_nav.erb
+++ b/source/layouts/_documentation_nav.erb
@@ -23,7 +23,7 @@
         <h3 class="docs-section-heading"><%= link_to "Advanced features", "/docs/advanced_features/service_discovery" %></h3>
         <ul style="list-style-type:none">
             <li class="doc-item">
-                <%= active_link_to "Joining services", "/docs/advanced_features/service_discovery" %>
+                <%= active_link_to "Service Discovery", "/docs/advanced_features/service_discovery" %>
             </li>
             <li class="doc-item">
                 <%= active_link_to "Clustering", "/docs/advanced_features/clustering" %>

--- a/source/layouts/_documentation_nav.erb
+++ b/source/layouts/_documentation_nav.erb
@@ -20,13 +20,16 @@
             </li>
         </ul>
 
-        <h3 class="docs-section-heading"><%= link_to "Armada Features", "/docs/armada_features/service_discovery" %></h3>
+        <h3 class="docs-section-heading"><%= link_to "Advanced features", "/docs/advanced_features/service_discovery" %></h3>
         <ul style="list-style-type:none">
             <li class="doc-item">
-                <%= active_link_to "Service Discovery", "/docs/armada_features/service_discovery" %>
+                <%= active_link_to "Joining services", "/docs/advanced_features/service_discovery" %>
             </li>
             <li class="doc-item">
-                <%= active_link_to "Clustering", "/docs/armada_features/clustering" %>
+                <%= active_link_to "Clustering", "/docs/advanced_features/clustering" %>
+            </li>
+            <li class="doc-item">
+                <%= active_link_to "Health-checks", "/docs/advanced_features/health_checks" %>
             </li>
         </ul>
 


### PR DESCRIPTION
`Armada Features` section was a bit misleading since it implied there are only two features. I've renamed this section to `Advanced features`.
Also added `health-checks` documentation, since it's one of the less obvious features.
Finally, I've removed all occurrences of port 22, in `armada run` outputs and fixed small fonts in `Clustering` doc.
